### PR TITLE
Handle auth loading state in App

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,9 @@ import Settings from './pages/Settings';
 import Errors from './pages/Errors';
 
 export default function App() {
-  const { session } = useContext(AuthContext);
+  const { session, loading } = useContext(AuthContext);
+
+  if (loading) return <div className="p-8">Loading…</div>;
 
   if (!session) return <Login />;
 


### PR DESCRIPTION
## Summary
- destructure the auth context to access the loading flag
- show a loading placeholder before rendering the auth gate or login view
- retain the existing admin requirement once authentication is ready

## Testing
- npm run lint *(fails: pre-existing lint errors in pages/Errors.tsx and Login.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a4ad78248329be50071b519fce03