### PR TITLE
Clear page errors when data reload succeeds

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -14,6 +14,7 @@ export default function Dashboard() {
   const [err, setErr] = useState<string | null>(null);
 
   const load = useCallback(async () => {
+    setErr(null);
     const { data, error } = await supabase.rpc('admin_dashboard_metrics');
     if (error) setErr(error.message);
     else setData(data as Metrics);

--- a/src/pages/Drivers.tsx
+++ b/src/pages/Drivers.tsx
@@ -8,6 +8,7 @@ export default function Drivers() {
   const [err, setErr] = useState<string | null>(null);
 
   const load = useCallback(async () => {
+    setErr(null);
     const { data, error } = await supabase
       .from('profiles')
       .select('id,full_name,phone,email,bg_check,is_active')

--- a/src/pages/Errors.tsx
+++ b/src/pages/Errors.tsx
@@ -18,7 +18,7 @@ export async function logClientError(
   });
 }
 
-type Row = { id: number; user_id: string | null; context: string | null; location: string | null; message: string; details: any; created_at: string };
+type Row = { id: number; user_id: string | null; context: string | null; location: string | null; message: string; details: unknown | null; created_at: string };
 
 export default function Errors() {
   const [rows, setRows] = useState<Row[]>([]);
@@ -27,6 +27,7 @@ export default function Errors() {
   const pageSize = 50;
 
   const load = useCallback(async () => {
+    setErr(null);
     const from = page * pageSize;
     const to = from + pageSize - 1;
     const { data, error } = await supabase

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -14,8 +14,9 @@ export default function Login() {
     setBusy(true);
     try {
       await signInWithEmail(email, password);
-    } catch (e: any) {
-      setErr(e.message ?? 'Sign-in failed');
+    } catch (e: unknown) {
+      if (e instanceof Error) setErr(e.message ?? 'Sign-in failed');
+      else setErr('Sign-in failed');
     } finally {
       setBusy(false);
     }

--- a/src/pages/Riders.tsx
+++ b/src/pages/Riders.tsx
@@ -8,6 +8,7 @@ export default function Riders() {
   const [err, setErr] = useState<string | null>(null);
 
   const load = useCallback(async () => {
+    setErr(null);
     const { data, error } = await supabase
       .from('profiles')
       .select('id,full_name,phone,email,is_active')

--- a/src/pages/Rides.tsx
+++ b/src/pages/Rides.tsx
@@ -17,6 +17,7 @@ export default function Rides() {
   const channelRef = useRef<RealtimeChannel | null>(null);
 
   const load = useCallback(async () => {
+    setErr(null);
     const { data, error } = await supabase
       .from('rides')
       .select('id,rider_id,driver_id,status,requested_at,updated_at')


### PR DESCRIPTION
## Summary
- clear any stale error state before refreshing dashboard, rides, drivers, riders, and error log data
- tighten the error log row typing to avoid `any` usage flagged by lint
- harden login error handling to account for unknown error shapes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1a5608ffc8329a09bd467c0ed9173